### PR TITLE
Do not fail when VBoxManage is not on path

### DIFF
--- a/VirtualBox.ExtensionPack/tools/chocolateyInstall.ps1
+++ b/VirtualBox.ExtensionPack/tools/chocolateyInstall.ps1
@@ -19,7 +19,7 @@ try {
 
     $vboxManage = (Which VBoxManage),
       $vboxManageDefault |
-      ? { Test-Path $_ } |
+      ? { $_ -and { Test-Path $_ } } |
       Select -First 1
 
     if (!$vboxManage)


### PR DESCRIPTION
Test-Path will throw an exception if its argument is empty (which happens when VBoxManage is not on the path)
