### PR TITLE
Update HipChat to standalone client

### DIFF
--- a/HipChat/HipChat.nuspec
+++ b/HipChat/HipChat.nuspec
@@ -3,8 +3,7 @@
   <metadata>
     <id>HipChat</id>
     <title>HipChat Client</title>
-    <!-- really 1.20120926103402 -->
-    <version>1.2.103402</version>
+    <version>2.1.1010</version>
     <authors>Atlassian</authors>
     <owners>Ethan J Brown</owners>
     <summary>HipChat is instant messaging built for business.</summary>
@@ -21,7 +20,6 @@ Get your team off AIM, Google Talk, and Skype — HipChat was built for business
     <iconUrl>https://github.com/Iristyle/ChocolateyPackages/raw/master/HipChat/HipChat.png</iconUrl>
     <releaseNotes></releaseNotes>
     <dependencies>
-      <dependency id="AdobeAIR" />
     </dependencies>
   </metadata>
   <files>

--- a/HipChat/tools/chocolateyInstall.ps1
+++ b/HipChat/tools/chocolateyInstall.ps1
@@ -4,30 +4,13 @@ try {
 
   $hipParams = @{
     PackageName = $package;
-    FileFullPath = (Join-Path $Env:TEMP 'hipchat.air');
-    Url = 'http://downloads.hipchat.com/hipchat.air'
+    FileType = 'msi';
+    SilentArgs = '/qn';
+    Url = 'https://www.hipchat.com/downloads/latest/qtwindows'
   }
-
-  Get-ChocolateyWebFile @hipParams
-
-  $airInstall = 'Adobe AIR\Versions\1.0\Adobe AIR Application Installer.exe'
-  $airPath = $Env:CommonProgramFiles, ${Env:CommonProgramFiles(x86)} |
-    % { Join-Path $_ $airInstall } |
-    ? { Test-Path $_ } |
-    Select -First 1
-
-  if (!$airPath)
-  {
-    Write-ChocolateyFailure $package 'Could not find AIR installer!'
-    return
-  }
-
-  $installPath = Join-Path $Env:ProgramFiles 'Hipchat'
-  $airParams = @('-silent', '-eulaAccepted', '-programMenu',
-     '-location', "`"$installPath`"", "`"$($hipParams.FileFullPath)`"")
-
-  Start-ChocolateyProcessAsAdmin -exeToRun $airPath -statements $airParams
-
+    
+  Install-ChocolateyPackage @hipParams
+ 
   Write-ChocolateySuccess $package
 } catch {
   Write-ChocolateyFailure $package "$($_.Exception.Message)"

--- a/HipChat/tools/chocolateyUninstall.ps1
+++ b/HipChat/tools/chocolateyUninstall.ps1
@@ -15,7 +15,6 @@ try {
   $uninstallString = "$uninstallString" -replace '[}]', '`} /passive /norestart' # to work properly with the Invoke-Expression command, add silent arguments
 
   if ($uninstallString -ne "") {
-      Write-Host $uninstallString
       Invoke-Expression "$uninstallString" # start uninstaller
   }
 


### PR DESCRIPTION
There is now a native HipChat client for Windows (HipChat 2.x) with a different download URL and an msi installer instead of an Adobe AIR exe.

This is so different that it could be a new package, but `cinst hipchat` should not install the the Adobe AIR version (HipChat 1.x)
