### PR TITLE
fix download url of OpenSSL.Light

### DIFF
--- a/OpenSSL.Light/OpenSSL.Light.nuspec
+++ b/OpenSSL.Light/OpenSSL.Light.nuspec
@@ -7,7 +7,7 @@
     <authors>Shining Light Productions</authors>
     <owners>Ethan Brown</owners>
     <summary>Open Source SSL v2/v3 and TLS v1 toolkit</summary>
-    <description>This is really 1.0.1j, but the Nuget spec doesn't allow such version identifiers, so the file versions are used.
+    <description>This is really 1.0.1L, but the Nuget spec doesn't allow such version identifiers, so the file versions are used.
 
     The OpenSSL Project is a collaborative effort to develop a robust, commercial-grade, full-featured, and Open Source toolkit implementing the Secure Sockets Layer (SSL v2/v3) and Transport Layer Security (TLS v1) protocols as well as a full-strength general purpose cryptography library. The project is managed by a worldwide community of volunteers that use the Internet to communicate, plan, and develop the OpenSSL toolkit and its related documentation.
 

--- a/OpenSSL.Light/tools/chocolateyInstall.ps1
+++ b/OpenSSL.Light/tools/chocolateyInstall.ps1
@@ -11,8 +11,8 @@ try {
     #InnoSetup - http://unattended.sourceforge.net/InnoSetup_Switches_ExitCodes.html
     silentArgs = '/silent', '/verysilent', '/sp-', '/suppressmsgboxes',
       "/DIR=`"$installDir`"";
-    url = 'https://slproweb.com/download/Win32OpenSSL_Light-1_0_1j.exe'
-    url64bit = 'https://slproweb.com/download/Win64OpenSSL_Light-1_0_1j.exe'
+    url = 'https://slproweb.com/download/Win32OpenSSL_Light-1_0_1L.exe'
+    url64bit = 'http://slproweb.com/download/Win64OpenSSL_Light-1_0_1L.exe'
   }
 
   Install-ChocolateyPackage @params


### PR DESCRIPTION
I know this is not a complete update description for a package,
but as old versions are not down loadable It doesn't matter much, as we only can make use of the newest version, else the install is broken