### PR TITLE
Font download URL moved from Sourcefarce, sorry, Sourceforge to Github.

### DIFF
--- a/SourceCodePro/tools/chocolateyInstall.ps1
+++ b/SourceCodePro/tools/chocolateyInstall.ps1
@@ -10,7 +10,7 @@ try {
   $fontHelpersPath = (Join-Path (Get-CurrentDirectory) 'FontHelpers.ps1')
    . $fontHelpersPath
 
-  $fontUrl = 'http://sourceforge.net/projects/sourcecodepro.adobe/files/SourceCodePro_FontsOnly-1.017.zip/download'
+  $fontUrl = 'https://github.com/adobe-fonts/source-code-pro/archive/1.017R.zip'
   $destination = Join-Path $Env:Temp 'SourceCodePro'
 
   Install-ChocolateyZipPackage -url $fontUrl -unzipLocation $destination


### PR DESCRIPTION
package installation failed... (sorry about the formatting but chocloatey did it)


Chocolatey (v0.9.8.32) is installing 'sourcecodepro' and dependencies. By instal
ling you accept the license for 'sourcecodepro' and each dependency you are inst
alling.

SourceCodePro v1.017.1
Attempt to get headers for http://sourceforge.net/projects/sourcecodepro.adobe/f
iles/SourceCodePro_FontsOnly-1.017.zip/download failed.
  Exception calling "GetResponse" with "0" argument(s): "The remote server retur
ned an error: (404) Not Found."
Downloading  64 bit
  from 'http://sourceforge.net/projects/sourcecodepro.adobe/files/SourceCodePro_
FontsOnly-1.017.zip/download'
Write-Error :  did not finish successfully. Boo to the chocolatey gods!
-----------------------
[ERROR] Exception calling "GetResponse" with "0" argument(s): "The remote serve
r returned an error: (404) Not Found."
-----------------------
At C:\ProgramData\chocolatey\chocolateyinstall\helpers\functions\Write-Chocolat
eyFailure.ps1:30 char:3
+   Write-Error $errorMessage
+   ~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorExcep
   tion
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorExceptio
   n,Write-Error

Write-Error : SourceCodePro did not finish successfully. Boo to the chocolatey
gods!
-----------------------
[ERROR] Exception calling "GetResponse" with "0" argument(s): "The remote serve
r returned an error: (404) Not Found."
-----------------------
At C:\ProgramData\chocolatey\chocolateyinstall\helpers\functions\Write-Chocolat
eyFailure.ps1:30 char:3
+   Write-Error $errorMessage
+   ~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorExcep
   tion
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorExceptio
   n,Write-Error

Write-Error : Package 'SourceCodePro v1.017.1' did not install successfully: Ex
ception calling "GetResponse" with "0" argument(s): "The remote server returned
 an error: (404) Not Found."
At C:\ProgramData\chocolatey\chocolateyinstall\functions\Chocolatey-NuGet.ps1:9
0 char:17
+                 Write-Error "Package `'$installedPackageName v$installedPacka
geV ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorExcep
   tion
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorExceptio
   n,Write-Error

Finished installing 'sourcecodepro' and dependencies - if errors not shown in co
nsole, none detected. Check log for errors if unsure.
Write-Error : Chocolatey reported an unsuccessful exit code of 1
At line:109 char:21
+                     Write-Error "Chocolatey reported an unsuccessful exit cod
e o ...
+                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorExcep
   tion
+ FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorExceptio
   n,Write-Error

+++ Boxstarter finished Calling Chocolatey to install sourcecodepro. This may ta
ke several minutes to complete... 00:00:13.4012135
+++ Boxstarter starting Calling Chocolatey to install notepadplusplus.install. T
his may take several minutes to complete...
````