### PR TITLE
Fixed issue with Sublime3 on Windows 32 bit - ${Env:ProgramFiles(x86)} path doesn't exist which caused the install and uninstall scripts to fail

### DIFF
--- a/SublimeText3/tools/chocolateyInstall.ps1
+++ b/SublimeText3/tools/chocolateyInstall.ps1
@@ -3,9 +3,14 @@ $build = '3065'
 $installFolder = 'Sublime Text 3'
 
 try {
-
-  $installedPath = (Join-Path "${Env:\ProgramFiles(x86)}" $installFolder),
-    (Join-Path $Env:ProgramFiles $installFolder) |
+  
+  $paths = (Join-Path $Env:ProgramFiles $installFolder)
+  
+  if (${Env:\ProgramFiles(x86)}) {
+	$paths = $paths, (Join-Path "${Env:\ProgramFiles(x86)}" $installFolder)
+  }
+  
+  $installedPath = $paths |
     ? { Test-Path $_ } |
     Select -First 1
 

--- a/SublimeText3/tools/chocolateyUninstall.ps1
+++ b/SublimeText3/tools/chocolateyUninstall.ps1
@@ -3,7 +3,13 @@ $installFolder = 'Sublime Text 3'
 
 try {
 
-  $path = ${Env:ProgramFiles(x86)}, $Env:ProgramFiles |
+  $paths = $Env:ProgramFiles
+  
+  if (${Env:ProgramFiles(x86)}) {
+	$paths = $paths, ${Env:ProgramFiles(x86)}
+  }
+
+  $path = $paths |
     % { Join-Path $_ $installFolder } |
     ? { Test-Path $_ } |
     Select -First 1


### PR DESCRIPTION
Fixed issue with Sublime3 on Windows 32 bit - ${Env:ProgramFiles(x86)} path doesn't exist which caused the install and uninstall scripts to fail