### PR TITLE
Fix PyWin32 package to work on Powershell 2.0

### DIFF
--- a/PyWin32/tools/chocolateyInstall.ps1
+++ b/PyWin32/tools/chocolateyInstall.ps1
@@ -50,9 +50,8 @@ try {
 
   $pythonVersion = &$localPython --version 2>&1
 
-  $simpleVersion = $pythonVersion |
-    Select-String -Pattern '^.*\s+(\d\.\d)(\.\d+){0,1}$' |
-    % { $_.Matches.Groups[1].Value }
+  $pythonVersion -match '^.*\s+(\d\.\d)(\.\d+){0,1}$'
+  $simpleVersion = $matches[1]
 
   # http://www.jordanrinke.com/2011/06/22/pywin32-silent-install/
 


### PR DESCRIPTION
The Matches member of the MatchInfo object returned by the Select-String
cmdlet was introduced in Powershell 3.0.