### PR TITLE
nuget.vs package installation fixed

### DIFF
--- a/Nuget.vs/tools/chocolateyInstall.ps1
+++ b/Nuget.vs/tools/chocolateyInstall.ps1
@@ -1,25 +1,18 @@
-try {
-  $package = 'NuGet.vs'
+$package = 'NuGet.vs'
 
-  $params = @{
-    PackageName = $package;
-    VsixUrl = 'http://visualstudiogallery.msdn.microsoft.com/27077b70-9dad-4c64-adcf-c7cf6bc9970c/file/37502/30/NuGet.Tools.vsix';
-  }
-
-  $vsKeys = Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\VisualStudio' |
-    Select -ExpandProperty PsChildName
-
-  # VS 2012, VS 2010
-  '11.0', '10.0' |
-    % {
-      if ($vsKeys -contains $_)
-      {
-        Install-ChocolateyVsixPackage @params -VsVersion [int]$_
-      }
-    }
-
-  Write-ChocolateySuccess $package
-} catch {
-  Write-ChocolateyFailure $package "$($_.Exception.Message)"
-  throw
+$params = @{
+  PackageName = $package;
+  VsixUrl = 'http://visualstudiogallery.msdn.microsoft.com/27077b70-9dad-4c64-adcf-c7cf6bc9970c/file/37502/30/NuGet.Tools.vsix';
 }
+
+$vsKeys = Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\VisualStudio' |
+		Select -ExpandProperty PsChildName
+
+# VS 2012, VS 2010
+'11.0', '10.0' |
+  % {
+    if ($vsKeys -contains $_)
+    {
+      Install-ChocolateyVsixPackage @params -VsVersion ($_ -as [int])
+    }
+  }


### PR DESCRIPTION
please take a look and if it's okay, rebuild the package ;)

the issue was with this line:
`Install-ChocolateyVsixPackage @params -VsVersion [int]$_`

It was failing with this message:

>Cannot process argument transformation on parameter 'vsVersion'. Cannot convert value "[int]10.0" to type
 "System.Int32". Error: "Input string was not in a correct format."
 At C:\ProgramData\chocolatey\helpers\functions\Write-ChocolateyFailure.ps1:24 char:3
 +   throw "$failureMessage"
 +   ~~~~~~~~~~~~~~~~~~~~~~~
     + CategoryInfo          : OperationStopped: (Cannot process ...orrect format.":String) [], RuntimeException
     + FullyQualifiedErrorId : Cannot process argument transformation on parameter 'vsVersion'. Cannot convert value "[ 
    int]10.0" to type "System.Int32". Error: "Input string was not in a correct format."
The install of nuget.vs was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\NuGet.vs\tools\chocolateyInstall.ps1'.
 See log for details.

