### PR TITLE
Update for latest chocolatey release

### DIFF
--- a/AWSTools.Powershell/tools/chocolateyInstall.ps1
+++ b/AWSTools.Powershell/tools/chocolateyInstall.ps1
@@ -1,16 +1,10 @@
 $package = 'AWSTools.Powershell'
 
-try {
-  $params = @{
-    packageName = $package;
-    fileType = 'msi';
-    silentArgs = '/quiet';
-    url = 'http://sdk-for-net.amazonwebservices.com/latest/AWSToolsAndSDKForNet.msi';
-  }
-
-  Install-ChocolateyPackage @params
-  Write-ChocolateySuccess $package
-} catch {
-  Write-ChocolateyFailure $package "$($_.Exception.Message)"
-  throw
+$params = @{
+  packageName = $package;
+  fileType = 'msi';
+  silentArgs = '/quiet';
+  url = 'http://sdk-for-net.amazonwebservices.com/latest/AWSToolsAndSDKForNet.msi';
 }
+
+Install-ChocolateyPackage @params


### PR DESCRIPTION
The current chocolatey release has removed the long-deprecated `Write-ChocolateySuccess` and `Write-ChocolateyFailure` functions.

https://github.com/chocolatey/choco/issues/2469